### PR TITLE
Add scripts to manage database schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 #### Setup
 * run `yarn install` to install dependencies
-* set DB_URL as an environemnt variable
+* set DATABASE_URL as an environment variable
+  * It should be a postgres connection string of the form `postgres://$user:$pass@localhost:5432/$dbname` which matches the database you have set up for the project
+* run `yarn run db:init` to create the (empty) tables the app expects
+  * run `yarn run db:clear` to wipe the tables but leave the database
 
 #### To run locally
 

--- a/db/util.js
+++ b/db/util.js
@@ -1,0 +1,17 @@
+
+// Chains queries together using the given connection pool
+//   - Is NOT transactional
+//   - Re-throws errors
+function executeInSequence (pool, queries) {
+  return queries
+    .reduce(
+      (chain, q) => chain.then(() => pool.query(q)),
+      Promise.resolve())
+    .then(() => console.log("success!"))
+    .catch(e => setImmediate(() => {throw e}));
+}
+
+
+module.exports = {
+ executeInSequence 
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "start": "node index.js",
     "heroku-postbuild": "cd client && yarn && yarn run build",
-    "test": "mocha ./routesTest"
+    "test": "mocha ./routesTest",
+    "db:init": "scripts/initDb.js",
+    "db:clear": "scripts/clearDb.js"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/scripts/clearDb.js
+++ b/scripts/clearDb.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const { executeInSequence } = require('../db/util');
+const pool = require('../db');
+
+const queries = [
+  'term',
+  'synonym',
+  'author',
+  'action',
+  'entry',
+  'requested'
+].map(tableName => `DROP TABLE IF EXISTS ${tableName} CASCADE;`);
+
+executeInSequence(pool, queries)
+  .then(() => pool.end());
+

--- a/scripts/initDb.js
+++ b/scripts/initDb.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const { executeInSequence } = require('../db/util');
+const pool = require('../db');
+
+const queries = [
+  'CREATE TABLE term(term VARCHAR (60) PRIMARY KEY);',
+  'CREATE TABLE synonym( term VARCHAR (60) NOT NULL, sort_as VARCHAR (60) NOT NULL, PRIMARY KEY (term, sort_as));',
+  'CREATE TABLE author( author_id SERIAL PRIMARY KEY, name VARCHAR (60), identity VARCHAR (3000));',
+  'CREATE TABLE action(id SERIAL PRIMARY KEY, title VARCHAR(20));',
+  'CREATE TABLE entry(entry_id serial PRIMARY KEY, term VARCHAR (60) NOT NULL REFERENCES term(term), definition VARCHAR (3000) NOT NULL, explanation VARCHAR (3000), author SERIAL REFERENCES author(author_id), action INTEGER NOT NULL REFERENCES action(id), time_submitted TIMESTAMPTZ, last_updated TIMESTAMPTZ);',
+  'CREATE TABLE requested( term VARCHAR (60) PRIMARY KEY, fulfilled INTEGER NOT NULL);'
+]
+
+executeInSequence(pool, queries)
+  .then(() => pool.end());
+


### PR DESCRIPTION
Some basic database management scripts. These would be made obsolete by adopting an ORM.

Also created a fun little helper method for executing multiple queries against a connection pool. 