### PR TITLE
[Paulette] Fix warnings for non-used Component

### DIFF
--- a/client/src/blurbs.js
+++ b/client/src/blurbs.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { welcomeBlurb } from "./utils/TextBlurbs";
 
 function DisagreementBlurb(props) {

--- a/client/src/tooltips.js
+++ b/client/src/tooltips.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { TooltipButton } from './Libraries/ReactToolboxLibrary';
 
 function Tooltips(props) {


### PR DESCRIPTION
Fix for warning in /client/src/blurbs.js and /client/src/tooltips.js

1:17  warning  'Component' is defined but never used  no-unused-vars