### PR TITLE
Disable multiline during testing

### DIFF
--- a/client/src/Forms/DefineForm.js
+++ b/client/src/Forms/DefineForm.js
@@ -17,6 +17,7 @@ const defaultFieldValues = {
   termDefinition: "",
   termMeaningToSubmitter: "",
   submitterIdentities: "",
+  isUnitTest: false,
 };
 
 export default class DefineForm extends React.Component {
@@ -113,8 +114,11 @@ export default class DefineForm extends React.Component {
       termMeaningToSubmitter,
       submitterIdentities,
       stateBar,
-      snackbarMessage
+      snackbarMessage,
     } = this.state;
+    const {
+      isUnitTest,
+    } = this.props;
 
     return(
       <ThemeProvider theme={theme}>
@@ -126,6 +130,7 @@ export default class DefineForm extends React.Component {
               onTimeoutSnackBar={this.handleSnackbarTimeout.bind(this)}
               stateBar={stateBar}
               snackbarMessage={snackbarMessage}
+              isUnitTest={isUnitTest}
               inputs={[
                 {
                   labelInput: 'Name',

--- a/client/src/Forms/DefineForm.unit.test.js
+++ b/client/src/Forms/DefineForm.unit.test.js
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer";
 import DefineForm from './DefineForm';
 
 test('Definition Form?', () => {
-  const component = renderer.create(<DefineForm />);
+  const component = renderer.create(<DefineForm isUnitTest={true} />);
   const jsonForm = component.toJSON();
   expect(jsonForm).toMatchSnapshot();
 });

--- a/client/src/Forms/FormComponent.js
+++ b/client/src/Forms/FormComponent.js
@@ -12,14 +12,15 @@ export default class Form extends Component {
     stateBar: false,
     onSubmit: (e) => { e.preventDefault() },
     onClickSnackBar: (e, i) => { e.preventDefault() },
-    onTimeoutSnackBar: (e,i) => { e.preventDefault() }
+    onTimeoutSnackBar: (e,i) => { e.preventDefault() },
+    isUnitTest: false,
   }
 
-  createInputs = (inputs) => {
+  createInputs = (inputs, isUnitTest) => {
     return inputs.map((input, index) => {
       return (<InputForm key={index} label={input.label} value={input.value} labelInput={input.labelInput}
                          isRequired={input.isRequired} showError={input.showError} errorStyle={input.errorStyle}
-                         onChange={input.onChange}/>)
+                         onChange={input.onChange} multiline={input.multiline} isUnitTest={isUnitTest} />)
     })
   }
 
@@ -28,7 +29,7 @@ export default class Form extends Component {
   }
 
   render() {
-    const {title, content, inputs, onSubmit, onClickSnackBar, onTimeoutSnackBar, stateBar, snackbarMessage} = this.props;
+    const {title, content, inputs, onSubmit, onClickSnackBar, onTimeoutSnackBar, stateBar, snackbarMessage, isUnitTest} = this.props;
     return (
       <div className="flex-container" data-testid='form-container'>
         <form onSubmit={onSubmit} data-testid='request-form'>
@@ -38,7 +39,7 @@ export default class Form extends Component {
             <span className='error'>* Required</span>
 
             <div className='inputsBox'>
-              {this.createInputs(inputs)}
+              {this.createInputs(inputs, isUnitTest)}
             </div>
             <div className='submitBox'>
               <Button className='queerButton' onMouseUp={onSubmit} label='Submit' raised primary/>

--- a/client/src/Forms/FormComponent.unit.test.js
+++ b/client/src/Forms/FormComponent.unit.test.js
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer";
 import Form from './FormComponent';
 
 test('termRequest?', () => {
-  const component = renderer.create(<Form title="Request a Term" inputs={[{labelInput:'What term do you want defined?', isRequired:true}]} />);
+  const component = renderer.create(<Form title="Request a Term" inputs={[{labelInput:'What term do you want defined?', isRequired:true}]} isUnitTest={true} />);
   const jsonForm = component.toJSON();
   expect(jsonForm).toMatchSnapshot();
 });

--- a/client/src/Forms/RequestForm.js
+++ b/client/src/Forms/RequestForm.js
@@ -52,6 +52,9 @@ export default class RequestForm extends Component {
 
   render() {
     const { showErrorTerm, Term, stateBar, snackbarMessage } = this.state;
+    const {
+      isUnitTest,
+    } = this.props;
 
     return (
       <ThemeProvider theme={theme}>
@@ -66,6 +69,7 @@ export default class RequestForm extends Component {
               onTimeoutSnackBar={this.handleSnackbarTimeout.bind(this)}
               stateBar={stateBar}
               snackbarMessage={snackbarMessage}
+              isUnitTest={isUnitTest}
         >
         </Form>
       </ThemeProvider>

--- a/client/src/Forms/RequestForm.unit.test.js
+++ b/client/src/Forms/RequestForm.unit.test.js
@@ -3,7 +3,7 @@ import renderer from "react-test-renderer";
 import RequestForm from './RequestForm';
 
 test('Request Form?', () => {
-  const component = renderer.create(<RequestForm />);
+  const component = renderer.create(<RequestForm isUnitTest={true} />);
   const jsonForm = component.toJSON();
   expect(jsonForm).toMatchSnapshot();
 });

--- a/client/src/Forms/__snapshots__/FormComponent.unit.test.js.snap
+++ b/client/src/Forms/__snapshots__/FormComponent.unit.test.js.snap
@@ -1,0 +1,86 @@
+exports[`test termRequest? 1`] = `
+<div
+  className="flex-container"
+  data-testid="form-container">
+  <form
+    data-testid="request-form"
+    onSubmit={[Function]}>
+    <div
+      className="form">
+      <div
+        className="page-title">
+        Request a Term
+      </div>
+      <div />
+      <span
+        className="error">
+        * Required
+      </span>
+      <div
+        className="inputsBox">
+        <div
+          className="formInput">
+          <label>
+            What term do you want defined?
+          </label>
+           
+          <span
+            className="error">
+            *
+          </span>
+          <div
+            className="queerInput"
+            data-react-toolbox="input">
+            <input
+              className=""
+              data-testid="request-input"
+              defaultValue={undefined}
+              disabled={false}
+              maxLength={50}
+              name={undefined}
+              onChange={[Function]}
+              onKeyPress={undefined}
+              required={false}
+              role="input"
+              style={
+                Object {
+                  "background": "transparent",
+                }
+              }
+              type="Text"
+              value={undefined} />
+            <span
+              className={undefined} />
+            <span
+              className={undefined}
+              hidden={undefined}>
+              Your answer
+            </span>
+            <span
+              className={undefined}>
+              0
+              /
+              50
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        className="submitBox">
+        <button
+          className=" queerButton"
+          data-react-toolbox="button"
+          disabled={false}
+          href={undefined}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchStart={[Function]}
+          type="button">
+          Submit
+        </button>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/client/src/Pages/InputFormComponent.js
+++ b/client/src/Pages/InputFormComponent.js
@@ -26,13 +26,14 @@ export default class InputForm extends Component {
   };
 
   render() {
-    const { inputType, labelInput, inputHint, labelRequiredMessage, isRequired, value, label, showError, maxLength, multiline, isUnitTest } = this.props;
+    const { inputType, labelInput, inputHint, labelRequiredMessage, isRequired, value, label, showError, maxLength, isUnitTest } = this.props;
     const style = showError ? errorStyle : normalStyle;
+    const multiline = this.props.multiline && !isUnitTest; /* Disabled during tests due to a bug in react-toolbox that breaks specs when multiline is enabled in the context of unit tests */
 
     return (
       <div className={style}>
         <label>{labelInput}</label>&nbsp;{(isRequired  && <span className="error">*</span> )}
-        <Input data-testid='request-input' className="queerInput" style={{background: 'transparent'}} type={inputType} hint={inputHint} value={value} onChange={this.handleChange.bind(this, label, isRequired)} maxLength={maxLength} multiline={multiline && !isUnitTest} />
+        <Input data-testid='request-input' className="queerInput" style={{background: 'transparent'}} type={inputType} hint={inputHint} value={value} onChange={this.handleChange.bind(this, label, isRequired)} maxLength={maxLength} multiline={multiline} />
         {(showError  &&
           <label className='error errorMessage'>{labelRequiredMessage}</label>)
         }

--- a/client/src/Pages/InputFormComponent.js
+++ b/client/src/Pages/InputFormComponent.js
@@ -14,7 +14,9 @@ export default class InputForm extends Component {
     inputHint: 'Your answer',
     onChange: () => {},
     labelRequiredMessage: 'This is a required question',
-    maxLength: 50
+    maxLength: 50,
+    multiline: false,
+    isUnitTest: false,
   }
 
   handleChange = (label, isRequired, value) => {
@@ -24,13 +26,13 @@ export default class InputForm extends Component {
   };
 
   render() {
-    const { inputType, labelInput, inputHint, labelRequiredMessage, isRequired, value, label, showError, maxLength } = this.props;
+    const { inputType, labelInput, inputHint, labelRequiredMessage, isRequired, value, label, showError, maxLength, multiline, isUnitTest } = this.props;
     const style = showError ? errorStyle : normalStyle;
 
     return (
       <div className={style}>
         <label>{labelInput}</label>&nbsp;{(isRequired  && <span className="error">*</span> )}
-        <Input data-testid='request-input' className="queerInput" style={{background: 'transparent'}} type={inputType} hint={inputHint} value={value} onChange={this.handleChange.bind(this, label, isRequired)} maxLength={maxLength} />
+        <Input data-testid='request-input' className="queerInput" style={{background: 'transparent'}} type={inputType} hint={inputHint} value={value} onChange={this.handleChange.bind(this, label, isRequired)} maxLength={maxLength} multiline={multiline && !isUnitTest} />
         {(showError  &&
           <label className='error errorMessage'>{labelRequiredMessage}</label>)
         }

--- a/client/src/Pages/InputFormComponent.unit.test.js
+++ b/client/src/Pages/InputFormComponent.unit.test.js
@@ -3,11 +3,11 @@ import renderer from "react-test-renderer";
 import InputForm from './InputFormComponent';
 
 test('termRequest?', () => {
-  const component = renderer.create(<InputForm labelInput="What term do you want defined?"/>);
+  const component = renderer.create(<InputForm labelInput="What term do you want defined?" isUnitTest={true} />);
   const jsonForm = component.toJSON();
   expect(jsonForm).toMatchSnapshot();
 
-  const componentRequired = renderer.create(<InputForm labelInput="What term do you want defined?" isRequired={true}/>);
+  const componentRequired = renderer.create(<InputForm labelInput="What term do you want defined?" isRequired={true} isUnitTest={true} />);
   const jsonFormRequired = componentRequired.toJSON();
   expect(jsonFormRequired).toMatchSnapshot();
 });


### PR DESCRIPTION
Enabling `multiline` on the `Input` component from `react-toolbox` causes the specs to fail due to a bug in the library.

Adds the `isUnitTest` prop to temporarily disable the `multiline` attribute in testing contexts.