### PR TITLE
Sort terms in search bar by number of definitions

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -38,11 +38,11 @@ class App extends Component {
       def: '',
       my_term: props.term,
       entries: [],
+      countedTerms: [],
       terms: [],
       entriesLoading: true
     };
 
-    fetch('/terms').then(res => {return res.json()}).then(res => {this.setState({terms: res.sort()})}); //i think this is causing an error
     this.handleChange = this.handleTermChange.bind(this);
 
   }
@@ -55,6 +55,21 @@ class App extends Component {
       this.setState({my_term: termFromPath});
       this.getDefListWithSortAs(termFromPath.toLowerCase());
     };
+
+    fetch('/terms/counts')
+      .then(res => res.json())
+      .then(countedTerms => {
+        this.setState({
+          countedTerms: countedTerms
+        })
+      })
+      .then(() => {
+        this.setState({
+          terms: this.state.countedTerms.map(term => {
+            return term.term
+          })
+        })
+      })
   }
 
   getDefListWithSortAs(searchterm) {
@@ -116,7 +131,7 @@ class App extends Component {
       <meta property="og:site_name" content="Queer Undefined"/>
       <meta property="og:title" content={pageTitle}/>
       <link rel="canonical" href={canonicalUrl} />
-      
+
     </Helmet>
     <div className="header-wrapper">
       <a className="header" href="/">queer undefined</a>

--- a/client/tests/SearchTerm.integ.test.js
+++ b/client/tests/SearchTerm.integ.test.js
@@ -56,8 +56,8 @@ it('Renders main page and searches for a term', async () => {
     // Assert
     expect(history.location.pathname).toBe('/*')
     expect(inputForSearchTerm.value).toBe('')
-    expect(fetch).toHaveBeenCalledWith('/terms')
-  
+    expect(fetch).toHaveBeenCalledWith('/terms/counts')
+
     // Act
     await fireEvent.change(inputForSearchTerm, {target: {value: 'abrogender'}})
 

--- a/server/routes/terms.js
+++ b/server/routes/terms.js
@@ -27,6 +27,24 @@ router.get('/', async (req, res) => {
     })
 })
 
+router.get('/counts', async (req, res) => {
+  var query = {
+    text: 'SELECT DISTINCT term, COUNT (term) FROM entry GROUP BY term'
+  };
+
+  pool.connect((err, client, release) => {
+    if (err) return console.error('Error acquiring client', err.stack);
+    client.query(query, (err, result) => {
+      release();
+      if (err) {
+        res.status(500).send('Error while retrieving term');
+        return console.error('Error executing query', err.stack);
+      }
+      res.send(result.rows.map(counted_terms => {return counted_terms}));
+    })
+  })
+})
+
 
 
 // router.post('/:term', async (req, res) => {

--- a/server/routes/terms.js
+++ b/server/routes/terms.js
@@ -40,7 +40,7 @@ router.get('/counts', async (req, res) => {
         res.status(500).send('Error while retrieving term');
         return console.error('Error executing query', err.stack);
       }
-      res.send(result.rows.map(counted_terms => {return counted_terms}));
+      res.send(result.rows);
     })
   })
 })

--- a/server/routes/terms.js
+++ b/server/routes/terms.js
@@ -29,7 +29,7 @@ router.get('/', async (req, res) => {
 
 router.get('/counts', async (req, res) => {
   var query = {
-    text: 'SELECT DISTINCT term, COUNT (term) FROM entry GROUP BY term'
+    text: 'SELECT DISTINCT LOWER(term) AS term, COUNT(term) FROM entry WHERE action=2 GROUP BY term ORDER BY count DESC, term ASC'
   };
 
   pool.connect((err, client, release) => {


### PR DESCRIPTION
I created a new `/terms/counts` route so that we can fetch all terms with their associated counts like the sample data below:

```
[
  {"term":"Pansexual","count":"3"},
  {"term":"Polysexual","count":"2"},
  {"term":"bigenderal/pangenderal/polygenderal","count":"1"},
  {"term":"dyke","count":"1"},
  {"term":"Non-Binary Bisexual","count":"1"}
]
```

The query for that route — `SELECT DISTINCT term, COUNT (term) FROM entry GROUP BY term` — automatically sorts each term first by count descending, then alphabetically ascending. So I changed the `fetch` call in `App.js` to get data from `/terms/counts` instead of `/terms` to easily render the terms in the correct order in the input list.

Additionally I updated the test snapshot for FormComponent. I don't know when that changed, but it was a space issue. After that update, all tests were green! ✅

__To do__: Add the ability to choose to sort alphabetically, by most definitions, or most recently defined. But I need more details about how that should look/work.