### PR TITLE
Add dismiss & reject buttons back to /reporteddefs page

### DIFF
--- a/client/src/Pages/ReportedDefs.js
+++ b/client/src/Pages/ReportedDefs.js
@@ -38,11 +38,13 @@ class ReportedDefs extends Component {
   }
 
   render() {
+    let { auth } = this.props;
+
     //fix this up:
     return (
     <ThemeProvider theme={theme}>
       <div>
-        {this.props.auth.isAuthenticated() && <ResultList style={{display:"flex", flexDirection:"column", alignContent:"center"}} entries={this.state.reported}/>}
+        {this.props.auth.isAuthenticated() && <ResultList style={{display:"flex", flexDirection:"column", alignContent:"center"}} entries={this.state.reported} auth={auth} />}
       </div>
     </ThemeProvider>
     );

--- a/client/src/Pages/ResultCard.js
+++ b/client/src/Pages/ResultCard.js
@@ -115,7 +115,7 @@ class ResultCard extends Component {
         </CardText>
         {(this.props.entry["action"] === 1) && <div><Button className="reject" label="reject" onClick={this.rejectPotential} raised />
                                      <Button className="accept" label="accept" onClick={this.acceptPotential} raised primary /></div>}
-        {(this.props.entry["action"] === 4 && this.isAuthenticated) && <div><Button className="accept" label="dismiss" onClick={this.acceptPotential} raised />
+        {(this.props.entry["action"] === 4 && this.isAuthenticated && window.location.pathname === '/reporteddefs') && <div><Button className="accept" label="dismiss" onClick={this.acceptPotential} raised />
                                      <Button className="reject" label="reject" onClick={this.rejectPotential} raised primary /></div>}
       </Card>}
     </div>


### PR DESCRIPTION
I removed `this.isAuthenticated` from the `ResultCard` component since:

- The `isAuthenticated` prop isn't being passed to `<ResultCard />` in `PotentialDefs.js` nor `ReportedDefs.js`.
- `this.isAuthenticated` is being used for only potential defs in `ResultCard.js`, not reported defs.
- Both `PotentialDefs.js` and `ReportedDefs.js` handle authentication already.

As far as I know, this removal doesn't affect other parts of the app and allowed the `Dismiss` and `Reject` buttons to reappear. The functionality for each button is already defined in `ReportedDefs.js`.