### PR TITLE
Buttons on potentialdefs page and report form are blue, should be red like bottom nav buttons

### DIFF
--- a/client/src/Forms/ReportForm/presentation.js
+++ b/client/src/Forms/ReportForm/presentation.js
@@ -33,7 +33,7 @@ const ModalButtons = (reportCb, hideCb, preventSubmission) =>
     onClick: hideCb
    }, {
     label: 'Report',
-    primary: true,
+    className: 'queerButton',
     raised: true,
     onClick: reportCb,
     disabled: preventSubmission

--- a/client/src/Pages/ResultCard.js
+++ b/client/src/Pages/ResultCard.js
@@ -114,9 +114,9 @@ class ResultCard extends Component {
          {(this.props.entry["action"] === 4) && this.reportsFor(this.props.entry)}
         </CardText>
         {(this.props.entry["action"] === 1) && <div><Button className="reject" label="reject" onClick={this.rejectPotential} raised />
-                                     <Button className="accept" label="accept" onClick={this.acceptPotential} raised primary /></div>}
+      <Button className="accept queerButton" label="accept" onClick={this.acceptPotential} raised /></div>}
         {(this.props.entry["action"] === 4 && this.isAuthenticated) && <div><Button className="accept" label="dismiss" onClick={this.acceptPotential} raised />
-                                     <Button className="reject" label="reject" onClick={this.rejectPotential} raised primary /></div>}
+      <Button className="reject queerButton" label="reject" onClick={this.rejectPotential} raised /></div>}
       </Card>}
     </div>
     );


### PR DESCRIPTION
I added the `queerButton` class and removed the `primary` option from the following buttons to change them from blue to red:

- The `ACCEPT` button for potential defs on the `/potentialdefs` page
- The `REJECT` button for reported defs on the `/reporteddefs` page
- The `REPORT` button for the report form