### PR TITLE
Fix button overlap with form inputs

### DIFF
--- a/client/src/stylesheets/tooltips.css
+++ b/client/src/stylesheets/tooltips.css
@@ -2,6 +2,7 @@
   position: fixed;
   bottom: 15px;
   right: 15px;
+  z-index: 100;
 }
 
 .tooltips .queerButton {


### PR DESCRIPTION
### Summary Of Changes
- Just simply added a z-index to make sure form input fields don't overlap with navigation lootlip buttons.
### Testing
- Didn't see the need to add testing
### Questions
- Would we be interested in adding a break point so we can stack the horizontal buttons vertically at a certain screen size?